### PR TITLE
fix: injectHeaders が response.user=nil でクラッシュする問題 (v1.6.1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,4 +65,4 @@ kong-plugin-oidc (PRIORITY: 1000)
 
 ## パッケージ管理
 
-LuaRocksで管理。`kong-plugin-oidc-1.6.0-1.rockspec`がビルド定義。Dockerfile内で`luarocks make`実行。
+LuaRocksで管理。`kong-plugin-oidc-1.6.1-1.rockspec`がビルド定義。Dockerfile内で`luarocks make`実行。

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,9 @@ USER root
 RUN apt-get update && apt-get install -y --no-install-recommends unzip && rm -rf /var/lib/apt/lists/*
 
 COPY kong/ /plugins/kong
-COPY kong-plugin-oidc-1.6.0-1.rockspec /plugins/
+COPY kong-plugin-oidc-1.6.1-1.rockspec /plugins/
 
 WORKDIR /plugins
-RUN luarocks make kong-plugin-oidc-1.6.0-1.rockspec
+RUN luarocks make kong-plugin-oidc-1.6.1-1.rockspec
 
 USER kong

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ docker pull ghcr.io/suwa-sh/kong-plugin-oidc:latest
 | タグ | 内容 |
 |------|------|
 | `latest` | 最新ビルド |
-| `kong-3.11.0.8-1.6.0` | Kong 3.11.0.8 + プラグイン 1.6.0 |
+| `kong-3.11.0.8-1.6.1` | Kong 3.11.0.8 + プラグイン 1.6.1 |
 
 `KONG_PLUGINS` 環境変数に `oidc` を追加して使用する:
 

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -107,6 +107,13 @@
 - [x] マルチノード構成でのセッション共有確認（E2E-05: Docker Compose 2台構成で Kong-1 ログイン → Kong-2 セッション有効）
   - テストケース一覧: [spec/e2e/README.md](../spec/e2e/README.md)
 
+### 9. バグフィックス v1.6.1
+
+- [x] [issue #1](https://github.com/suwa-sh/kong-plugin-oidc/issues/1) 対応: `response.user = nil` で `injectHeaders` が 500 でクラッシュする
+  - `handler.lua` に `non_nil_sources` ヘルパーを追加し、nil を除外したテーブルを `injectHeaders` に渡す
+  - `utils.lua` の `injectHeaders` に `if source then` ガードを追加（防御的ガード）
+  - ユニットテスト追加: `response.user = nil` の Auth Code フローで id_token からクレーム解決されること
+
 ## 設定例（完成イメージ）
 
 ```yaml

--- a/kong-plugin-oidc-1.6.1-1.rockspec
+++ b/kong-plugin-oidc-1.6.1-1.rockspec
@@ -1,5 +1,5 @@
 package = "kong-plugin-oidc"
-version = "1.6.0-1"
+version = "1.6.1-1"
 source = {
     url = "git://github.com/suwa-sh/kong-plugin-oidc",
     tag = "main",

--- a/kong/plugins/oidc/handler.lua
+++ b/kong/plugins/oidc/handler.lua
@@ -1,11 +1,25 @@
 local OidcHandler = {
-    VERSION = "1.6.0",
+    VERSION = "1.6.1",
     PRIORITY = 1000,
 }
 -- luacheck: ignore 212/self
 local utils = require("kong.plugins.oidc.utils")
 local filter = require("kong.plugins.oidc.filter")
 local handle, make_oidc, introspect, verify_bearer_jwt
+
+-- Build a sources table that excludes nil values.
+-- Lua の { nil, x } のようなテーブルリテラルは nil ホールを生成し
+-- `#t` の結果が未定義になるため、nil を除外したテーブルを明示的に構築する。
+local function non_nil_sources(...)
+  local sources = {}
+  for i = 1, select("#", ...) do
+    local v = select(i, ...)
+    if v then
+      sources[#sources + 1] = v
+    end
+  end
+  return sources
+end
 
 function OidcHandler:configure(configs)
   -- Map openidc debug log level to configured Nginx log level
@@ -112,7 +126,7 @@ handle = function(oidcConfig)
       elseif response.id_token then
         utils.injectGroups(response.id_token, oidcConfig.groups_claim)
       end
-      utils.injectHeaders(oidcConfig.header_names, oidcConfig.header_claims, { response.user, response.id_token })
+      utils.injectHeaders(oidcConfig.header_names, oidcConfig.header_claims, non_nil_sources(response.user, response.id_token))
       if (not oidcConfig.disable_userinfo_header
           and response.user) then
         utils.injectUser(response.user, oidcConfig.userinfo_header_name)

--- a/kong/plugins/oidc/utils.lua
+++ b/kong/plugins/oidc/utils.lua
@@ -207,16 +207,19 @@ function M.injectHeaders(header_names, header_claims, sources)
     claim = header_claims[i]
     kong.service.request.clear_header(header)
     for j = 1, #sources do
-      local source, claim_value
-      source = sources[j]
-      claim_value = source[claim]
-      -- Convert table to string if claim is a table
-      if type(claim_value) == "table" then
-        claim_value = table.concat(claim_value, ", ")
-      end
-      if (source and source[claim]) then
-        kong.service.request.set_header(header, claim_value)
-        break
+      local source = sources[j]
+      -- Guard against nil sources: 呼び出し側で nil を除外しているが
+      -- 他の呼び出し元からの防御として再チェックする
+      if source then
+        local claim_value = source[claim]
+        -- Convert table to string if claim is a table
+        if type(claim_value) == "table" then
+          claim_value = table.concat(claim_value, ", ")
+        end
+        if claim_value then
+          kong.service.request.set_header(header, claim_value)
+          break
+        end
       end
     end
   end

--- a/spec/unit/handler_spec.lua
+++ b/spec/unit/handler_spec.lua
@@ -338,6 +338,45 @@ describe("handler", function()
         assert.are.same({ "admin" }, kong.ctx.shared.authenticated_groups)
       end)
 
+      -- H-12c: issue #1 regression
+      -- session_contents.user = false のとき response.user が nil になり、
+      -- { response.user, response.id_token } が nil ホール付きテーブルリテラルになる。
+      -- handler.lua の non_nil_sources ヘルパーで nil を除外し、id_token 側から
+      -- header_claims を解決できることを検証する。
+      it("response.userがnilでheader_claims設定ありの場合_id_tokenからクレームが解決されてクラッシュしないこと", function()
+        local headers_set = {}
+        package.loaded["resty.openidc"].authenticate = function()
+          return {
+            user = nil,
+            id_token = {
+              sub = "u1",
+              iss = "https://example.com",
+              email = "user@example.com",
+              custom_claim_1 = "E12345",
+            },
+            access_token = "access-tok",
+          }, nil
+        end
+        ngx.var.uri = "/api"
+        ngx.var.request_uri = "/api"
+        kong.service.request.set_header = function(name, value)
+          headers_set[name] = value
+        end
+        kong.service.request.clear_header = function() end
+        kong.client.authenticate = function() end
+        local config = mocks.make_config({
+          header_names  = { "X-User-EmployeeId", "X-User-Email" },
+          header_claims = { "custom_claim_1", "email" },
+        })
+
+        assert.has_no.errors(function()
+          handler:access(config)
+        end)
+
+        assert.are.equal("E12345", headers_set["X-User-EmployeeId"])
+        assert.are.equal("user@example.com", headers_set["X-User-Email"])
+      end)
+
       -- H-13
       it("unauthorized_requestエラーの場合_401が返されること", function()
         package.loaded["resty.openidc"].authenticate = function()

--- a/spec/unit/utils_spec.lua
+++ b/spec/unit/utils_spec.lua
@@ -297,6 +297,28 @@ describe("utils", function()
 
       assert.are.equal("admin, editor, viewer", headers_set["X-Roles"])
     end)
+
+    -- U-21b: issue #1 regression
+    -- injectHeaders が nil source を安全に扱えることを検証する防御的テスト。
+    -- handler.lua 側の non_nil_sources で nil は除外されるが、
+    -- utils.lua 側でも if source then ガードで防御する。
+    it("sourcesリストの要素がnilの場合_クラッシュせず次のsourceから解決されること", function()
+      local headers_set = {}
+      kong.service.request.set_header = function(name, value)
+        headers_set[name] = value
+      end
+      kong.service.request.clear_header = function() end
+      -- Lua 5.1 では { nil, x } の #t は実装依存のため、 rawset で明示的に nil を
+      -- 埋め、n フィールドで長さを指定した疑似的な sources を構築する
+      local sources = { [1] = false, [2] = { email = "user@example.com" } }
+      -- false は nil ではないが、if source then ガードでは同じく false パスに入るため
+      -- 防御的ガードの動作検証として有効。
+
+      assert.has_no.errors(function()
+        utils.injectHeaders({ "X-Email" }, { "email" }, sources)
+      end)
+      assert.are.equal("user@example.com", headers_set["X-Email"])
+    end)
   end)
 
   ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Fixes #1 — `session_contents.user = false`（デフォルト）の Authorization Code フローで `response.user` が nil になり、`{ response.user, response.id_token }` という nil ホール付きテーブルリテラルが `injectHeaders` に渡されて HTTP 500 でクラッシュする問題を修正
- `handler.lua` に `non_nil_sources` ヘルパーを追加し、nil を除外した sources を `injectHeaders` に渡す（メイン修正）
- `utils.lua` の `injectHeaders` に `if source then` 防御的ガードを追加
- バージョン 1.6.0 → 1.6.1

## 修正内容

### handler.lua

- L13-22: `non_nil_sources(...)` ヘルパー関数を追加
- L129: `{ response.user, response.id_token }` → `non_nil_sources(response.user, response.id_token)`
- L2: `VERSION = "1.6.1"`

### utils.lua

- L199-226 `injectHeaders`: `if source then` ガードで nil ソースをスキップ

### バージョン関連

- `kong-plugin-oidc-1.6.0-1.rockspec` → `kong-plugin-oidc-1.6.1-1.rockspec`
- `Dockerfile` の rockspec 参照を更新
- `README.md` / `CLAUDE.md` のバージョン表記を更新

### テスト追加

- `spec/unit/handler_spec.lua` H-12c: Auth Code フローで `response.user = nil` のとき `id_token` から `header_claims` が解決されてクラッシュしないこと
- `spec/unit/utils_spec.lua` U-21b: `injectHeaders` の `if source then` 防御的ガードが機能すること

## Test plan

- [x] ユニットテスト追加（H-12c, U-21b）
- [ ] CI: luacheck / qlty / busted / 統合テスト / E2E / Docker build
- [ ] マージ後、`v1.6.1` タグ push → CD が GHCR に `ghcr.io/suwa-sh/kong-plugin-oidc:kong-3.11.0.8-1.6.1` を公開