### PR TITLE
fix: X-Credential-Identifier に sub を優先設定する (#3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ bash spec/e2e/run-e2e.sh
 - `X-USERINFO`: ユーザー情報（Base64 エンコード JSON）
 - `X-Access-Token`: アクセストークン（生トークン文字列、または `access_token_as_bearer=yes` で `Bearer <token>` 形式）
 - `X-ID-Token`: ID トークン（Base64 エンコード JSON）
-- `X-Credential-Identifier`: ユーザーの `sub` クレーム
+- `X-Credential-Identifier`: ユーザーの `sub` クレーム（`sub` が無い場合は `preferred_username` にフォールバック）
 
 Kong の認証情報として `kong.client.authenticate()` が呼ばれ、以下が設定される:
 
@@ -195,6 +195,8 @@ credential = {
     username = "preferred_username クレームの値"
 }
 ```
+
+`X-Credential-Identifier` には `credential.id`（= `sub`）が優先的に設定される。OIDC の subject identifier はユーザーの安定識別子であり、下流サービスの認証文脈に適しているためである。`sub` が存在しない例外的なトークンの場合のみ、後方互換のため `credential.username`（= `preferred_username`）にフォールバックする。
 
 グループ情報はトークンの `groups` クレーム（設定変更可能）から取得し、`kong.ctx.shared.authenticated_groups` に設定される。Kong の認可プラグインで利用可能。
 

--- a/kong/plugins/oidc/utils.lua
+++ b/kong/plugins/oidc/utils.lua
@@ -146,7 +146,9 @@ local function set_consumer(consumer, credential)
     clear_header(constants.HEADERS.CONSUMER_USERNAME)
   end
 
-  if credential and credential.username then
+  if credential and credential.id then
+    set_header(constants.HEADERS.CREDENTIAL_IDENTIFIER, credential.id)
+  elseif credential and credential.username then
     set_header(constants.HEADERS.CREDENTIAL_IDENTIFIER, credential.username)
   else
     clear_header(constants.HEADERS.CREDENTIAL_IDENTIFIER)

--- a/spec/unit/utils_spec.lua
+++ b/spec/unit/utils_spec.lua
@@ -353,6 +353,88 @@ describe("utils", function()
       assert.is_nil(user.id)
       assert.is_nil(user.username)
     end)
+
+    -- U-24a (issue #3): subとpreferred_usernameの両方がある場合_X-Credential-Identifierにsubが設定されること
+    it("subとpreferred_username両方ありの場合_X-Credential-Identifierにsubが設定されること", function()
+      local headers_set = {}
+      kong.client.authenticate = function() end
+      kong.service.request.set_header = function(name, value)
+        headers_set[name] = value
+      end
+      kong.service.request.clear_header = function(name)
+        headers_set[name] = nil
+      end
+      local user = { sub = "248289761001", preferred_username = "alice" }
+
+      utils.setCredentials(user)
+
+      assert.are.equal("248289761001", headers_set["X-Credential-Identifier"])
+    end)
+
+    -- U-24b (issue #3): preferred_usernameがない場合でも_X-Credential-Identifierにsubが設定されること
+    it("preferred_usernameなしの場合_X-Credential-Identifierにsubが設定されること", function()
+      local headers_set = {}
+      kong.client.authenticate = function() end
+      kong.service.request.set_header = function(name, value)
+        headers_set[name] = value
+      end
+      kong.service.request.clear_header = function(name)
+        headers_set[name] = nil
+      end
+      local user = { sub = "248289761001" }
+
+      utils.setCredentials(user)
+
+      assert.are.equal("248289761001", headers_set["X-Credential-Identifier"])
+    end)
+
+    -- U-24c (issue #3): subなし・preferred_usernameありの場合_後方互換でusernameにフォールバックすること
+    it("subなし_preferred_usernameありの場合_X-Credential-Identifierがusernameにフォールバックすること", function()
+      local headers_set = {}
+      kong.client.authenticate = function() end
+      kong.service.request.set_header = function(name, value)
+        headers_set[name] = value
+      end
+      kong.service.request.clear_header = function(name)
+        headers_set[name] = nil
+      end
+      local user = { preferred_username = "alice" }
+
+      utils.setCredentials(user)
+
+      assert.are.equal("alice", headers_set["X-Credential-Identifier"])
+    end)
+
+    -- U-24d (issue #3): subとpreferred_username両方ない場合_X-Credential-Identifierがクリアされること
+    it("subもpreferred_usernameもない場合_X-Credential-Identifierがクリアされること", function()
+      local cleared = {}
+      kong.client.authenticate = function() end
+      kong.service.request.set_header = function() end
+      kong.service.request.clear_header = function(name)
+        cleared[name] = true
+      end
+      local user = { name = "Alice" }
+
+      utils.setCredentials(user)
+
+      assert.is_true(cleared["X-Credential-Identifier"])
+    end)
+
+    -- U-24e (issue #3): credential.idが優先されkong.client.authenticateにsubが渡されること
+    it("kong.client.authenticateに渡されるcredentialのidがsubであること", function()
+      local authenticated_credential
+      kong.client.authenticate = function(_, credential)
+        authenticated_credential = credential
+      end
+      kong.service.request.set_header = function() end
+      kong.service.request.clear_header = function() end
+      local user = { sub = "user-123", preferred_username = "alice" }
+
+      utils.setCredentials(user)
+
+      assert.are.equal("user-123", authenticated_credential.id)
+      assert.are.equal("alice", authenticated_credential.username)
+    end)
   end)
 
   ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #3

## Summary

- README の説明では `X-Credential-Identifier` にユーザーの `sub` クレームが入る前提だったが、実装では `preferred_username` が設定されており、`preferred_username` 不在時にはヘッダーがクリアされる不整合があった
- `set_consumer` で `credential.id`（= `sub`）を優先し、無い場合のみ後方互換として `credential.username`（= `preferred_username`）にフォールバックするように修正
- `kong.client.authenticate()` に渡す credential 構造（`id` / `username`）は変更していないため、`kong.client.get_credential().username` の意味は維持

## Changes

- `kong/plugins/oidc/utils.lua`: `set_consumer` のヘッダー設定順を変更（`credential.id` 優先 → `credential.username` フォールバック → クリア）
- `spec/unit/utils_spec.lua`: U-24a〜U-24e の単体テスト 5 件を追加
  - U-24a: `sub` と `preferred_username` 両方ありで `sub` が設定される
  - U-24b: `preferred_username` 無しでも `sub` が設定される
  - U-24c: `sub` 無し時に `preferred_username` へフォールバック
  - U-24d: 両方無い場合はクリア
  - U-24e: `kong.client.authenticate()` の credential.id が `sub` のまま
- `README.md`: フォールバック挙動と意図（OIDC subject identifier の安定性）を追記

## Test plan

- [ ] CI で `luacheck` と `busted` のユニットテストが通ること
- [ ] 既存テスト（U-22, U-23 など）が引き続き通ること
- [ ] 新規テスト U-24a〜U-24e が通ること

https://claude.ai/code/session_01VCSHJpTsCeF3ossRWpxjkR

---
_Generated by [Claude Code](https://claude.ai/code/session_01VCSHJpTsCeF3ossRWpxjkR)_