### PR TITLE
fix: validate_scope=yes で複数スコープを正しく検証できない問題を修正 (#5)

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -113,6 +113,10 @@
   - `handler.lua` に `non_nil_sources` ヘルパーを追加し、nil を除外したテーブルを `injectHeaders` に渡す
   - `utils.lua` の `injectHeaders` に `if source then` ガードを追加（防御的ガード）
   - ユニットテスト追加: `response.user = nil` の Auth Code フローで id_token からクレーム解決されること
+- [x] [issue #5](https://github.com/suwa-sh/kong-plugin-oidc/issues/5) 対応: `validate_scope=yes` で複数スコープ設定を正しく検証できない
+  - `handler.lua` に `token_contains_required_scopes` ヘルパーを追加し、設定側 `oidcConfig.scope` とトークン側 `res.scope` をスペース区切りで分解して包含関係を検証
+  - 設定の全必須スコープがトークン側に含まれている場合のみ通過、不足/`res.scope` が nil の場合は 403
+  - ユニットテスト追加: 複数スコープ成功ケース、必須スコープ不足ケース、`res.scope` が nil のケース
 
 ## 設定例（完成イメージ）
 

--- a/kong/plugins/oidc/handler.lua
+++ b/kong/plugins/oidc/handler.lua
@@ -21,6 +21,27 @@ local function non_nil_sources(...)
   return sources
 end
 
+-- OAuth/OIDC のスコープはスペース区切りリストとして扱う。
+-- 必須スコープ（required_scope）に含まれるすべてのスコープが
+-- トークン側スコープ（token_scope）に含まれているかを検証する。
+local function token_contains_required_scopes(token_scope, required_scope)
+  if type(token_scope) ~= "string" or type(required_scope) ~= "string" then
+    return false
+  end
+  local token_scopes = {}
+  for scope in token_scope:gmatch("%S+") do
+    token_scopes[scope] = true
+  end
+  local has_required = false
+  for required in required_scope:gmatch("%S+") do
+    has_required = true
+    if not token_scopes[required] then
+      return false
+    end
+  end
+  return has_required
+end
+
 function OidcHandler:configure(configs)
   -- Map openidc debug log level to configured Nginx log level
   -- Iterate through all configs and take the highest priority (least verbose) level
@@ -203,16 +224,7 @@ introspect = function(oidcConfig)
       return nil
     end
     if oidcConfig.validate_scope == "yes" then
-      local validScope = false
-      if res.scope then
-        for scope in res.scope:gmatch("([^ ]+)") do
-          if scope == oidcConfig.scope then
-            validScope = true
-            break
-          end
-        end
-      end
-      if not validScope then
+      if not token_contains_required_scopes(res.scope, oidcConfig.scope) then
         kong.log.err("Scope validation failed")
         return kong.response.error(ngx.HTTP_FORBIDDEN)
       end

--- a/spec/unit/handler_spec.lua
+++ b/spec/unit/handler_spec.lua
@@ -505,6 +505,68 @@ describe("handler", function()
         assert.are.equal(403, error_code)
       end)
 
+      -- H-18a: issue #5 regression
+      -- 複数の必須スコープがすべてトークンに含まれる場合は成功する
+      it("validate_scope有効で複数必須スコープがすべてトークンに含まれる場合_成功すること", function()
+        setup_bearer_header()
+        package.loaded["resty.openidc"].introspect = function()
+          return { sub = "u1", preferred_username = "user1", scope = "openid profile email" }, nil
+        end
+        local error_called = false
+        kong.response.error = function() error_called = true end
+        local config = mocks.make_config({
+          introspection_endpoint = "https://example.com/introspect",
+          validate_scope = "yes",
+          scope = "openid profile",
+        })
+
+        handler:access(config)
+
+        assert.is_false(error_called)
+      end)
+
+      -- H-18c: issue #5 regression
+      -- 複数の必須スコープのうち一部しかトークンに含まれない場合は 403
+      it("validate_scope有効で必須スコープが一部不足する場合_403が返されること", function()
+        setup_bearer_header()
+        package.loaded["resty.openidc"].introspect = function()
+          return { sub = "u1", scope = "openid" }, nil
+        end
+        local error_code
+        kong.response.error = function(code) error_code = code end
+        kong.log.err = function() end
+        local config = mocks.make_config({
+          introspection_endpoint = "https://example.com/introspect",
+          validate_scope = "yes",
+          scope = "openid profile",
+        })
+
+        handler:access(config)
+
+        assert.are.equal(403, error_code)
+      end)
+
+      -- H-18d: issue #5 regression
+      -- res.scope が nil の場合は 403
+      it("validate_scope有効でres_scopeがnilの場合_403が返されること", function()
+        setup_bearer_header()
+        package.loaded["resty.openidc"].introspect = function()
+          return { sub = "u1" }, nil
+        end
+        local error_code
+        kong.response.error = function(code) error_code = code end
+        kong.log.err = function() end
+        local config = mocks.make_config({
+          introspection_endpoint = "https://example.com/introspect",
+          validate_scope = "yes",
+          scope = "openid",
+        })
+
+        handler:access(config)
+
+        assert.are.equal(403, error_code)
+      end)
+
       -- H-18b
       it("Bearerトークンなし_bearer_onlyでもない場合_nilが返されること", function()
         ngx.req.get_headers = function() return {} end


### PR DESCRIPTION
## Summary

closes #5

`config.validate_scope = "yes"` のとき、`config.scope` に `openid profile` のような複数スコープを指定すると、トークン側に同じスコープ群が含まれていても 403 になる不具合を修正しました。

### 原因

`handler.lua` の `introspect()` でトークン側 `res.scope` だけをスペース分解し、設定側 `oidcConfig.scope` は分解せずに比較していたため、設定側が複数スコープのときに常に不一致となっていました。

```lua
-- 修正前
for scope in res.scope:gmatch("([^ ]+)") do
  if scope == oidcConfig.scope then  -- "openid" == "openid profile" → false
    validScope = true
    break
  end
end
```

### 修正内容

- `handler.lua` に `token_contains_required_scopes(token_scope, required_scope)` ヘルパーを追加
- 設定側・トークン側の両方をスペース区切りで分解し、設定の全必須スコープがトークンに含まれていれば成功と判定
- `res.scope` が nil または必須スコープが空の場合は従来どおり 403
- `introspect()` 内のロジックを `token_contains_required_scopes` 呼び出しに置き換え

### 受け入れ条件と対応

- [x] `scope = "openid"` かつ `res.scope = "openid profile"` で成功する（既存 H-17 で担保）
- [x] `scope = "openid profile"` かつ `res.scope = "openid profile email"` で成功する（H-18a 追加）
- [x] `scope = "openid profile"` かつ `res.scope = "openid"` で 403 になる（H-18c 追加）
- [x] `res.scope` が nil の場合は 403 になる（H-18d 追加）
- [x] 既存の bearer_only / introspection のエラー処理は変わらない（H-18, H-19 で担保）

## Test plan

- [ ] `busted spec/unit/handler_spec.lua` を実行し、追加した H-18a / H-18c / H-18d を含む handler テストがすべて通ること
- [ ] `luacheck kong/` / `qlty check --all` で静的解析エラーが出ないこと
- [ ] 手動確認: `validate_scope=yes` + `scope: "openid profile"` の設定で `scope: "openid profile email"` を返すトークンが 200、`scope: "openid"` のみのトークンが 403 になること

https://claude.ai/code/session_01RuiJBr5ckDpJ3FFpWPcLmu

---
_Generated by [Claude Code](https://claude.ai/code/session_01RuiJBr5ckDpJ3FFpWPcLmu)_