### PR TITLE
fix: WWW-Authenticate ヘッダのインジェクション/構文崩壊を防ぐ sanitize を追加 (#8)

### DIFF
--- a/kong/plugins/oidc/handler.lua
+++ b/kong/plugins/oidc/handler.lua
@@ -197,7 +197,9 @@ introspect = function(oidcConfig)
     end
     if err then
       if oidcConfig.bearer_only == "yes" then
-        ngx.header["WWW-Authenticate"] = 'Bearer realm="' .. oidcConfig.realm .. '",error="' .. err .. '"' -- luacheck: ignore 122
+        local realm = utils.sanitize_header_value(oidcConfig.realm)
+        local error_value = utils.sanitize_header_value(err)
+        ngx.header["WWW-Authenticate"] = 'Bearer realm="' .. realm .. '",error="' .. error_value .. '"' -- luacheck: ignore 122
         return kong.response.error(ngx.HTTP_UNAUTHORIZED)
       end
       return nil

--- a/kong/plugins/oidc/utils.lua
+++ b/kong/plugins/oidc/utils.lua
@@ -225,6 +225,19 @@ function M.injectHeaders(header_names, header_claims, sources)
   end
 end
 
+-- WWW-Authenticate quoted-string 値の sanitize（CRLFインジェクション/構文崩壊の防御、RFC 6750 §3 / RFC 7235）
+function M.sanitize_header_value(value)
+  if type(value) ~= "string" then
+    return "server_error"
+  end
+  local sanitized = value:gsub("[%c]", "")
+  sanitized = sanitized:gsub("\\", "\\\\"):gsub('"', '\\"')
+  if #sanitized > 200 then
+    sanitized = sanitized:sub(1, 200)
+  end
+  return sanitized
+end
+
 function M.has_bearer_access_token()
   local header = ngx.req.get_headers()['Authorization']
   if header and header:find(" ") then

--- a/spec/unit/handler_spec.lua
+++ b/spec/unit/handler_spec.lua
@@ -545,6 +545,36 @@ describe("handler", function()
         assert.truthy(ngx.header["WWW-Authenticate"])
         assert.truthy(ngx.header["WWW-Authenticate"]:find("Bearer realm="))
       end)
+
+      -- H-19b: issue #8 regression
+      -- err にCRLFや " が混入した場合でも WWW-Authenticate ヘッダが
+      -- 単一の quoted-string として崩れないことを検証する。
+      it("errにCRLFやクォートが含まれる場合_WWW-Authenticateヘッダがsanitizeされること", function()
+        setup_bearer_header()
+        package.loaded["resty.openidc"].introspect = function()
+          return nil, 'invalid_token"\r\nX-Injected: pwned'
+        end
+        kong.response.error = function() end
+        local config = mocks.make_config({
+          introspection_endpoint = "https://example.com/introspect",
+          bearer_only = "yes",
+          realm = "kong",
+        })
+
+        handler:access(config)
+
+        local header = ngx.header["WWW-Authenticate"]
+        assert.truthy(header)
+        -- CRLF が含まれない（ヘッダインジェクション不可）
+        assert.is_nil(header:find("\r"))
+        assert.is_nil(header:find("\n"))
+        -- realm の構造は維持される
+        assert.truthy(header:find('Bearer realm="kong"'))
+        -- err のクォートはエスケープされ、quoted-string 内に閉じ込められている
+        assert.truthy(header:find('error="invalid_token\\"', 1, true))
+        -- 末尾は単一の閉じクォート
+        assert.are.equal('"', header:sub(-1))
+      end)
     end)
 
     ---------------------------------------------------------------------------

--- a/spec/unit/utils_spec.lua
+++ b/spec/unit/utils_spec.lua
@@ -383,6 +383,63 @@ describe("utils", function()
   end)
 
   ---------------------------------------------------------------------------
+  -- sanitize_header_value (U-30 〜 U-36) issue #8
+  -- WWW-Authenticate ヘッダの quoted-string 値の安全化
+  ---------------------------------------------------------------------------
+  describe("sanitize_header_value", function()
+    -- U-30
+    it("CR/LFを含む場合_除去されること", function()
+      local result = utils.sanitize_header_value("invalid_token\r\nX-Bad: 1")
+
+      assert.are.equal("invalid_tokenX-Bad: 1", result)
+    end)
+
+    -- U-31
+    it("ダブルクォートを含む場合_エスケープされること", function()
+      local result = utils.sanitize_header_value('foo"bar')
+
+      assert.are.equal('foo\\"bar', result)
+    end)
+
+    -- U-32
+    it("バックスラッシュを含む場合_エスケープされること", function()
+      local result = utils.sanitize_header_value("foo\\bar")
+
+      assert.are.equal("foo\\\\bar", result)
+    end)
+
+    -- U-33
+    it("制御文字を含む場合_除去されること", function()
+      local result = utils.sanitize_header_value("foo\t\0\bbar")
+
+      assert.are.equal("foobar", result)
+    end)
+
+    -- U-34
+    it("非文字列の場合_server_errorが返されること", function()
+      assert.are.equal("server_error", utils.sanitize_header_value(nil))
+      assert.are.equal("server_error", utils.sanitize_header_value(123))
+      assert.are.equal("server_error", utils.sanitize_header_value({}))
+    end)
+
+    -- U-35
+    it("200文字超の場合_切り詰められること", function()
+      local long = string.rep("a", 300)
+
+      local result = utils.sanitize_header_value(long)
+
+      assert.are.equal(200, #result)
+    end)
+
+    -- U-36
+    it("通常の文字列の場合_変更されないこと", function()
+      local result = utils.sanitize_header_value("invalid_token")
+
+      assert.are.equal("invalid_token", result)
+    end)
+  end)
+
+  ---------------------------------------------------------------------------
   -- has_common_item (U-26 〜 U-29)
   ---------------------------------------------------------------------------
   describe("has_common_item", function()


### PR DESCRIPTION
## Summary

Fixes #8

`handler.lua` の `introspect()` で `WWW-Authenticate` に `err` / `realm` を sanitize せず文字列連結していたため、CR/LF や `"` を含む値で **構文崩壊** や **ヘッダインジェクション** が発生し得る状態を修正した。

### 変更内容

- **`utils.lua`**: `sanitize_header_value()` ヘルパーを追加
  - 制御文字（`%c` = CR/LF/NUL/TAB等）を除去
  - `\` と `"` を quoted-string 仕様に従ってエスケープ（RFC 7235）
  - 200 文字に制限（過剰に長い OP 応答でヘッダが暴れない）
  - 非文字列入力には `"server_error"` をフォールバック
- **`handler.lua`**: `introspect()` の `bearer_only` エラー経路で `realm` / `err` 両方に sanitize を適用
- **テスト**: ユニットテスト 7件追加
  - `U-30〜U-36`: `sanitize_header_value` の挙動（CRLF除去、`"`/`\` エスケープ、制御文字除去、非文字列、長さ制限、通常文字列）
  - `H-19b`: `bearer_only=yes` で悪意ある `err` を返したとき、`WWW-Authenticate` が単一の quoted-string として崩れず、CRLF が含まれないこと

### 受け入れ条件

- [x] `err` に CR/LF が含まれていても `WWW-Authenticate` に出力されない
- [x] `err` に `"` が含まれても単一の quoted-string として解釈可能（`\"` でエスケープ）
- [x] 通常の OP 応答でのヘッダは従来と実質同等（`Bearer realm="kong",error="token expired"` のまま）
- [x] sanitize ヘルパーのユニットテストがある

## Test plan

- [ ] CI: luacheck が通ること
- [ ] CI: ユニットテスト（busted）で U-30〜U-36 と H-19b が成功すること
- [ ] 既存の H-19（通常 err）が回帰していないこと
- [ ] 統合テスト: `bearer_only=yes` での無効トークン送信時、`WWW-Authenticate` が単一の正しい構文（CRLF・unescaped `"` なし）になること

https://claude.ai/code/session_01EW7gNSguL47fV1AzuvD9Qr

---
_Generated by [Claude Code](https://claude.ai/code/session_01EW7gNSguL47fV1AzuvD9Qr)_