### PR TITLE
feat: secret 系フィールドに encrypted / referenceable 属性を付与 (#6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,13 @@ bash spec/e2e/run-e2e.sh
 | `config.session_redis_database` | `0` | no | Redis データベース番号 |
 | `config.session_redis_ssl` | `no` | no | Redis への SSL 接続 |
 
+#### シークレットの取り扱い
+
+`client_secret` / `encryption_secret` / `session_redis_password` は `encrypted` / `referenceable` 属性付きで宣言されている。
+
+- **Kong keyring 暗号化**: keyring を有効化している環境では DB 上で暗号化されて保存される（[Kong Keyring](https://docs.konghq.com/gateway/latest/kong-enterprise/db-encryption/)）。keyring 未導入環境では従来どおり平文で保存される
+- **Vault 参照**: `{vault://env/OIDC_CLIENT_SECRET}` のような参照値を指定でき、ランタイムに解決される（[Kong Vault references](https://docs.konghq.com/gateway/latest/kong-enterprise/secrets-management/)）
+
 ### ログアウト設定
 
 | パラメータ | デフォルト | 必須 | 説明 |

--- a/kong/plugins/oidc/schema.lua
+++ b/kong/plugins/oidc/schema.lua
@@ -24,7 +24,9 @@ return {
           {
             client_secret = {
               type = "string",
-              required = true
+              required = true,
+              encrypted = true,
+              referenceable = true,
             }
           },
           {
@@ -131,7 +133,9 @@ return {
             -- https://github.com/bungle/lua-resty-session/tree/v4.0.5?tab=readme-ov-file#session-configuration
             encryption_secret = {
               type = "string",
-              required = true
+              required = true,
+              encrypted = true,
+              referenceable = true,
             }
           },
           {
@@ -199,7 +203,9 @@ return {
           {
             session_redis_password = {
               type = "string",
-              required = false
+              required = false,
+              encrypted = true,
+              referenceable = true,
             }
           },
           {

--- a/spec/unit/schema_spec.lua
+++ b/spec/unit/schema_spec.lua
@@ -1,0 +1,65 @@
+local mocks = require("spec.unit.helpers.mocks")
+
+describe("schema", function()
+  local schema
+
+  setup(function()
+    mocks.setup()
+    package.loaded["kong.plugins.oidc.schema"] = nil
+    schema = require("kong.plugins.oidc.schema")
+  end)
+
+  teardown(function()
+    package.loaded["kong.plugins.oidc.schema"] = nil
+    mocks.teardown()
+  end)
+
+  -- 名前で config の field 定義を引き当てる
+  local function find_field(name)
+    for _, entry in ipairs(schema.fields) do
+      if entry.config then
+        for _, field_entry in ipairs(entry.config.fields) do
+          local field_name, field_def = next(field_entry)
+          if field_name == name then
+            return field_def
+          end
+        end
+      end
+    end
+    return nil
+  end
+
+  ---------------------------------------------------------------------------
+  -- secret 系フィールドが encrypted / referenceable 属性を持つこと
+  ---------------------------------------------------------------------------
+  describe("secret fields", function()
+    -- S-01
+    it("client_secret_スキーマ定義_encryptedとreferenceableがtrueであること", function()
+      local field = find_field("client_secret")
+
+      assert.is_not_nil(field)
+      assert.is_true(field.required)
+      assert.is_true(field.encrypted)
+      assert.is_true(field.referenceable)
+    end)
+
+    -- S-02
+    it("encryption_secret_スキーマ定義_encryptedとreferenceableがtrueであること", function()
+      local field = find_field("encryption_secret")
+
+      assert.is_not_nil(field)
+      assert.is_true(field.required)
+      assert.is_true(field.encrypted)
+      assert.is_true(field.referenceable)
+    end)
+
+    -- S-03
+    it("session_redis_password_スキーマ定義_encryptedとreferenceableがtrueであること", function()
+      local field = find_field("session_redis_password")
+
+      assert.is_not_nil(field)
+      assert.is_true(field.encrypted)
+      assert.is_true(field.referenceable)
+    end)
+  end)
+end)


### PR DESCRIPTION
Closes #6

## Summary

- `client_secret` / `encryption_secret` / `session_redis_password` の 3 フィールドに `encrypted = true, referenceable = true` を付与
- Kong keyring 有効環境では DB 上で暗号化保存される
- `{vault://env/...}` 等の Vault 参照がランタイムに解決可能
- 既存の生値設定は引き続き動作（後方互換）

## Changes

- `kong/plugins/oidc/schema.lua`: 3 フィールドに `encrypted` / `referenceable` 属性を追加
- `spec/unit/schema_spec.lua`: S-01〜S-03 の単体テスト 3 件を追加
  - S-01: `client_secret` の属性検証
  - S-02: `encryption_secret` の属性検証
  - S-03: `session_redis_password` の属性検証
- `README.md`: 「シークレットの取り扱い」節を追加し keyring / Vault 参照について明記

## Test plan

- [ ] CI で luacheck / busted（unit 89 件）が通ること
- [ ] integration テスト（27 件）が通ること
- [ ] e2e テスト が通ること
- [ ] 既存の plugin 設定がそのまま動作する（後方互換）

## 互換性

breaking change なし。`encrypted` / `referenceable` は属性追加のみで型は変わらず、keyring 未導入環境では従来どおり平文保存。Vault 参照は opt-in。