### PR TITLE
chore(release): v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,36 @@
 
 このプロジェクトの変更履歴。フォーマットは [Keep a Changelog](https://keepachangelog.com/) に準拠し、[Semantic Versioning](https://semver.org/) に従う。
 
-## [Unreleased]
+## [1.7.0] - 2026-04-27
 
 ### ⚠ BREAKING CHANGES
 
-- **`ssl_verify` のデフォルト値を `"no"` から `"yes"` に変更** ([#7](https://github.com/suwa-sh/kong-plugin-oidc/issues/7))
+- **`ssl_verify` のデフォルト値を `"no"` から `"yes"` に変更** ([#7](https://github.com/suwa-sh/kong-plugin-oidc/issues/7) / [#14](https://github.com/suwa-sh/kong-plugin-oidc/pull/14))
   - 影響: `ssl_verify` を未指定で運用しており、かつ **HTTPS で自己署名証明書の OP** を使っている場合、Discovery / JWKS / Introspection / Token 取得リクエストで TLS 証明書検証が失敗するようになる
   - 影響なし: HTTP の OP を使用している、または既に `ssl_verify` を明示指定している場合
   - 移行手順:
     - 本番で正規の証明書 OP を使っている場合 → 対応不要（推奨される設定に揃う）
     - 自己署名証明書の OP を使っている dev 環境 → plugin config に `ssl_verify: "no"` を明示指定する
   - 動機: セキュアバイデフォルトの原則。MITM 耐性のない既定値で運用が継続するリスクを排除
+
+### Added
+
+- secret 系フィールド（`client_secret` / `encryption_secret` / `session_redis_password`）に `encrypted` / `referenceable` 属性を付与 ([#6](https://github.com/suwa-sh/kong-plugin-oidc/issues/6) / [#13](https://github.com/suwa-sh/kong-plugin-oidc/pull/13))
+  - Kong keyring 有効環境では DB 上で暗号化保存される
+  - `{vault://env/...}` 形式の Vault 参照がランタイムに解決される
+  - 既存の生値設定は引き続き動作（後方互換）
+- README に「シークレットの取り扱い」節を追加
+
+### Fixed
+
+- `X-Credential-Identifier` ヘッダーに `sub` クレームを優先設定するように修正 ([#3](https://github.com/suwa-sh/kong-plugin-oidc/issues/3) / [#9](https://github.com/suwa-sh/kong-plugin-oidc/pull/9))
+  - `sub` が無い場合のみ `preferred_username` にフォールバック
+  - README の説明と実装を一致させた
+- `header_claims` でドット区切りパス（例: `realm_access.roles`）を解決できるように修正 ([#4](https://github.com/suwa-sh/kong-plugin-oidc/issues/4) / [#11](https://github.com/suwa-sh/kong-plugin-oidc/pull/11))
+- `validate_scope=yes` で複数スコープを正しく検証できない問題を修正 ([#5](https://github.com/suwa-sh/kong-plugin-oidc/issues/5) / [#10](https://github.com/suwa-sh/kong-plugin-oidc/pull/10))
+  - 設定側 `scope` とトークン側 `scope` の両方をスペース区切りで分解して比較
+- `WWW-Authenticate` ヘッダに渡す `err` を sanitize するように修正 ([#8](https://github.com/suwa-sh/kong-plugin-oidc/issues/8) / [#12](https://github.com/suwa-sh/kong-plugin-oidc/pull/12))
+  - CRLF / `"` の除去・エスケープと長さ制限により、ヘッダインジェクションを防止
 
 ### Changed
 
@@ -22,4 +41,4 @@
 
 ## 過去の変更
 
-`v1.6.1` 以前の変更履歴は [Git タグ](https://github.com/suwa-sh/kong-plugin-oidc/tags) と [Releases](https://github.com/suwa-sh/kong-plugin-oidc/releases) を参照。
+`v1.6.1` 以前の変更履歴は [Git タグ](https://github.com/suwa-sh/kong-plugin-oidc/tags) を参照。

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,9 @@ USER root
 RUN apt-get update && apt-get install -y --no-install-recommends unzip && rm -rf /var/lib/apt/lists/*
 
 COPY kong/ /plugins/kong
-COPY kong-plugin-oidc-1.6.1-1.rockspec /plugins/
+COPY kong-plugin-oidc-1.7.0-1.rockspec /plugins/
 
 WORKDIR /plugins
-RUN luarocks make kong-plugin-oidc-1.6.1-1.rockspec
+RUN luarocks make kong-plugin-oidc-1.7.0-1.rockspec
 
 USER kong

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ docker pull ghcr.io/suwa-sh/kong-plugin-oidc:latest
 | タグ | 内容 |
 |------|------|
 | `latest` | 最新ビルド |
-| `kong-3.11.0.8-1.6.1` | Kong 3.11.0.8 + プラグイン 1.6.1 |
+| `kong-3.11.0.8-1.7.0` | Kong 3.11.0.8 + プラグイン 1.7.0 |
 
 `KONG_PLUGINS` 環境変数に `oidc` を追加して使用する:
 

--- a/kong-plugin-oidc-1.7.0-1.rockspec
+++ b/kong-plugin-oidc-1.7.0-1.rockspec
@@ -1,5 +1,5 @@
 package = "kong-plugin-oidc"
-version = "1.6.1-1"
+version = "1.7.0-1"
 source = {
     url = "git://github.com/suwa-sh/kong-plugin-oidc",
     tag = "main",

--- a/kong/plugins/oidc/handler.lua
+++ b/kong/plugins/oidc/handler.lua
@@ -1,5 +1,5 @@
 local OidcHandler = {
-    VERSION = "1.6.1",
+    VERSION = "1.7.0",
     PRIORITY = 1000,
 }
 -- luacheck: ignore 212/self


### PR DESCRIPTION
## リリース内容

v1.6.1 → **v1.7.0**

### ⚠ BREAKING CHANGE

`ssl_verify` のデフォルト値を `\"no\"` → `\"yes\"` に変更（#7 / #14）。
詳細と移行手順は [CHANGELOG](CHANGELOG.md) を参照。

### 含まれる変更

| 種別 | 内容 |
|---|---|
| ⚠ BREAKING | ssl_verify 既定値変更（#7 / #14） |
| Added | secret 系フィールドに encrypted/referenceable 属性（#6 / #13） |
| Fixed | X-Credential-Identifier に sub 優先（#3 / #9） |
| Fixed | header_claims のドット区切りパス対応（#4 / #11） |
| Fixed | validate_scope 複数スコープ検証（#5 / #10） |
| Fixed | WWW-Authenticate の err サニタイズ（#8 / #12） |

### バンプ対象

- \`kong-plugin-oidc-1.6.1-1.rockspec\` → \`kong-plugin-oidc-1.7.0-1.rockspec\`
- \`Dockerfile\`: rockspec 参照パスを更新
- \`kong/plugins/oidc/handler.lua\`: \`VERSION = \"1.7.0\"\`
- \`README.md\`: Docker タグ例を 1.7.0 に更新
- \`CHANGELOG.md\`: \`[1.7.0] - 2026-04-27\` セクションを確定

## Test plan

- [ ] CI（lint / unit / integration / e2e / build）がすべて通ること
- [ ] merge 後に \`v1.7.0\` タグを付けて push すると、CD ワークフローが GHCR にイメージを公開すること

## merge 後の手順

1. \`v1.7.0\` タグを main に付けて push
2. CD ワークフロー（\`.github/workflows/cd.yml\`）が GHCR に \`ghcr.io/suwa-sh/kong-plugin-oidc:kong-3.11.0.8-1.7.0\` と \`:latest\` を公開
3. GitHub Releases に CHANGELOG の該当節を貼り付けてリリースノート公開（任意）